### PR TITLE
Syntax for exceptions

### DIFF
--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -684,7 +684,9 @@ let module_ s =
   let funcs =
     List.map2 Source.(fun t f -> {f.it with ftype = t} @@ f.at)
       func_types func_bodies
-  in {types; tables; memories; globals; funcs; imports; exports; elems; data; start}
+  in
+  let exns = [] in (* TODO FIXME. *)
+  {types; tables; memories; globals; funcs; exns; imports; exports; elems; data; start}
 
 
 let decode name bs = at module_ (stream name bs)

--- a/interpreter/binary/decode.ml
+++ b/interpreter/binary/decode.ml
@@ -685,8 +685,8 @@ let module_ s =
     List.map2 Source.(fun t f -> {f.it with ftype = t} @@ f.at)
       func_types func_bodies
   in
-  let exns = [] in (* TODO FIXME. *)
-  {types; tables; memories; globals; funcs; exns; imports; exports; elems; data; start}
+  let exceptions = [] in (* TODO FIXME. *)
+  {types; tables; memories; globals; funcs; exceptions; imports; exports; elems; data; start}
 
 
 let decode name bs = at module_ (stream name bs)

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -381,6 +381,7 @@ let encode m =
       | Try _ -> assert false (* TODO FIXME. *)
       | Throw _ -> assert false (* TODO FIXME. *)
       | Rethrow -> assert false (* TODO FIXME. *)
+      | BrExn _ -> assert false (* TODO FIXME. *)
 
     let const c =
       list instr c.it; end_ ()

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -100,6 +100,7 @@ let encode m =
     let ref_type = function
       | FuncRefType -> vs7 (-0x10)
       | AnyRefType -> vs7 (-0x11)
+      | ExnRefType -> assert false (* TODO FIXME. *)
       | NullRefType -> assert false
 
     let value_type = function
@@ -408,6 +409,7 @@ let encode m =
       | TableImport t -> u8 0x01; table_type t
       | MemoryImport t -> u8 0x02; memory_type t
       | GlobalImport t -> u8 0x03; global_type t
+      | ExnImport t -> assert false (* TODO FIXME. *)
 
     let import im =
       let {module_name; item_name; idesc} = im.it in
@@ -453,6 +455,7 @@ let encode m =
       | TableExport x -> u8 1; var x
       | MemoryExport x -> u8 2; var x
       | GlobalExport x -> u8 3; var x
+      | ExnExport x -> assert false (* TODO FIXME. *)
 
     let export ex =
       let {name = n; edesc} = ex.it in

--- a/interpreter/binary/encode.ml
+++ b/interpreter/binary/encode.ml
@@ -381,7 +381,7 @@ let encode m =
       | Try _ -> assert false (* TODO FIXME. *)
       | Throw _ -> assert false (* TODO FIXME. *)
       | Rethrow -> assert false (* TODO FIXME. *)
-      | BrExn _ -> assert false (* TODO FIXME. *)
+      | BrOnExn _ -> assert false (* TODO FIXME. *)
 
     let const c =
       list instr c.it; end_ ()
@@ -410,7 +410,7 @@ let encode m =
       | TableImport t -> u8 0x01; table_type t
       | MemoryImport t -> u8 0x02; memory_type t
       | GlobalImport t -> u8 0x03; global_type t
-      | ExnImport t -> assert false (* TODO FIXME. *)
+      | ExceptionImport t -> assert false (* TODO FIXME. *)
 
     let import im =
       let {module_name; item_name; idesc} = im.it in
@@ -456,7 +456,7 @@ let encode m =
       | TableExport x -> u8 1; var x
       | MemoryExport x -> u8 2; var x
       | GlobalExport x -> u8 3; var x
-      | ExnExport x -> assert false (* TODO FIXME. *)
+      | ExceptionExport x -> assert false (* TODO FIXME. *)
 
     let export ex =
       let {name = n; edesc} = ex.it in

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -428,6 +428,7 @@ let create_export (inst : module_inst) (ex : export) : export_inst =
     | TableExport x -> ExternTable (table inst x)
     | MemoryExport x -> ExternMemory (memory inst x)
     | GlobalExport x -> ExternGlobal (global inst x)
+    | ExnExport x -> assert false (* TODO FIXME. *)
   in name, ext
 
 
@@ -472,7 +473,7 @@ let add_import (m : module_) (ext : extern) (im : import) (inst : module_inst)
 let init (m : module_) (exts : extern list) : module_inst =
   let
     { imports; tables; memories; globals; funcs; types;
-      exports; elems; data; start
+      exports; elems; data; start; exns
     } = m.it
   in
   if List.length exts <> List.length imports then

--- a/interpreter/exec/eval.ml
+++ b/interpreter/exec/eval.ml
@@ -428,7 +428,7 @@ let create_export (inst : module_inst) (ex : export) : export_inst =
     | TableExport x -> ExternTable (table inst x)
     | MemoryExport x -> ExternMemory (memory inst x)
     | GlobalExport x -> ExternGlobal (global inst x)
-    | ExnExport x -> assert false (* TODO FIXME. *)
+    | ExceptionExport x -> assert false (* TODO FIXME. *)
   in name, ext
 
 
@@ -473,7 +473,7 @@ let add_import (m : module_) (ext : extern) (im : import) (inst : module_inst)
 let init (m : module_) (exts : extern list) : module_inst =
   let
     { imports; tables; memories; globals; funcs; types;
-      exports; elems; data; start; exns
+      exports; elems; data; start; exceptions
     } = m.it
   in
   if List.length exts <> List.length imports then

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -214,7 +214,7 @@ let print_import m im =
     | ExternTableType t -> "table", string_of_table_type t
     | ExternMemoryType t -> "memory", string_of_memory_type t
     | ExternGlobalType t -> "global", string_of_global_type t
-    | ExternExnType t -> "exn", string_of_exn_type t
+    | ExternExceptionType t -> "exception", string_of_exception_type t
   in
   Printf.printf "  import %s \"%s\" \"%s\" : %s\n"
     category (Ast.string_of_name im.it.Ast.module_name)
@@ -228,7 +228,7 @@ let print_export m ex =
     | ExternTableType t -> "table", string_of_table_type t
     | ExternMemoryType t -> "memory", string_of_memory_type t
     | ExternGlobalType t -> "global", string_of_global_type t
-    | ExternExnType t -> "exn", string_of_exn_type t
+    | ExternExceptionType t -> "exception", string_of_exception_type t
   in
   Printf.printf "  export %s \"%s\" : %s\n"
     category (Ast.string_of_name ex.it.Ast.name) annotation

--- a/interpreter/script/run.ml
+++ b/interpreter/script/run.ml
@@ -214,6 +214,7 @@ let print_import m im =
     | ExternTableType t -> "table", string_of_table_type t
     | ExternMemoryType t -> "memory", string_of_memory_type t
     | ExternGlobalType t -> "global", string_of_global_type t
+    | ExternExnType t -> "exn", string_of_exn_type t
   in
   Printf.printf "  import %s \"%s\" \"%s\" : %s\n"
     category (Ast.string_of_name im.it.Ast.module_name)
@@ -227,6 +228,7 @@ let print_export m ex =
     | ExternTableType t -> "table", string_of_table_type t
     | ExternMemoryType t -> "memory", string_of_memory_type t
     | ExternGlobalType t -> "global", string_of_global_type t
+    | ExternExnType t -> "exn", string_of_exn_type t
   in
   Printf.printf "  export %s \"%s\" : %s\n"
     category (Ast.string_of_name ex.it.Ast.name) annotation

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -107,7 +107,7 @@ and instr' =
   | Try of block_type * instr list * instr list
   | Throw of var
   | Rethrow
-  | BrExn of var * var
+  | BrOnExn of var * var
 
 
 (* Globals & Functions *)
@@ -159,8 +159,8 @@ type memory_segment = string segment
 type exn = exn' Source.phrase
 and exn' =
 {
-  exvar : var;
-  extype : exn_type
+  xvar : var;
+  xtype : exception_type
 }
 
 (* Modules *)
@@ -173,7 +173,7 @@ and export_desc' =
   | TableExport of var
   | MemoryExport of var
   | GlobalExport of var
-  | ExnExport of var
+  | ExceptionExport of var
 
 type export = export' Source.phrase
 and export' =
@@ -188,7 +188,7 @@ and import_desc' =
   | TableImport of table_type
   | MemoryImport of memory_type
   | GlobalImport of global_type
-  | ExnImport of exn_type
+  | ExceptionImport of exception_type
 
 type import = import' Source.phrase
 and import' =
@@ -211,7 +211,7 @@ and module_' =
   data : string segment list;
   imports : import list;
   exports : export list;
-  exns : exn list
+  exceptions : exn list
 }
 
 
@@ -229,7 +229,7 @@ let empty_module =
   data = [];
   imports = [];
   exports = [];
-  exns = []
+  exceptions = []
 }
 
 open Source
@@ -247,7 +247,7 @@ let import_type (m : module_) (im : import) : extern_type =
   | TableImport t -> ExternTableType t
   | MemoryImport t -> ExternMemoryType t
   | GlobalImport t -> ExternGlobalType t
-  | ExnImport t -> ExternExnType t
+  | ExceptionImport t -> ExternExceptionType t
 
 let export_type (m : module_) (ex : export) : extern_type =
   let {edesc; _} = ex.it in
@@ -267,9 +267,9 @@ let export_type (m : module_) (ex : export) : extern_type =
   | GlobalExport x ->
     let gts = globals its @ List.map (fun g -> g.it.gtype) m.it.globals in
     ExternGlobalType (nth gts x.it)
-  | ExnExport x ->
-    let ets = exns its @ List.map (fun e -> e.it.extype) m.it.exns in
-    ExternExnType (nth ets x.it)
+  | ExceptionExport x ->
+    let ets = exceptions its @ List.map (fun e -> e.it.xtype) m.it.exceptions in
+    ExternExceptionType (nth ets x.it)
 
 let string_of_name n =
   let b = Buffer.create 16 in

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -107,6 +107,7 @@ and instr' =
   | Try of block_type * instr list * instr list
   | Throw of var
   | Rethrow
+  | BrExn of var * var
 
 
 (* Globals & Functions *)

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -156,8 +156,8 @@ type table_segment = var list segment
 type memory_segment = string segment
 
 (* Exceptions *)
-type exn = exn' Source.phrase
-and exn' =
+type exception_ = exception_' Source.phrase
+and exception_' =
 {
   xvar : var;
   xtype : exception_type
@@ -211,7 +211,7 @@ and module_' =
   data : string segment list;
   imports : import list;
   exports : export list;
-  exceptions : exn list
+  exceptions : exception_ list
 }
 
 
@@ -237,8 +237,8 @@ open Source
 let func_type_for (m : module_) (x : var) : func_type =
   (Lib.List32.nth m.it.types x.it).it
 
-let exn_type_for (m : module_) (x : var) : func_type =
-  (Lib.List32.nth m.it.types x.it).it
+let exception_type_for (m : module_) (x : var) : exception_type =
+  (Lib.List32.nth m.it.exceptions x.it).it.xtype
 
 let import_type (m : module_) (im : import) : extern_type =
   let {idesc; _} = im.it in

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -158,7 +158,8 @@ type memory_segment = string segment
 type exn = exn' Source.phrase
 and exn' =
 {
-  extype: exn_type
+  exvar : var;
+  extype : exn_type
 }
 
 (* Modules *)
@@ -233,6 +234,9 @@ let empty_module =
 open Source
 
 let func_type_for (m : module_) (x : var) : func_type =
+  (Lib.List32.nth m.it.types x.it).it
+
+let exn_type_for (m : module_) (x : var) : func_type =
   (Lib.List32.nth m.it.types x.it).it
 
 let import_type (m : module_) (im : import) : extern_type =

--- a/interpreter/syntax/ast.ml
+++ b/interpreter/syntax/ast.ml
@@ -154,6 +154,12 @@ and 'data segment' =
 type table_segment = var list segment
 type memory_segment = string segment
 
+(* Exceptions *)
+type exn = exn' Source.phrase
+and exn' =
+{
+  extype: exn_type
+}
 
 (* Modules *)
 
@@ -165,6 +171,7 @@ and export_desc' =
   | TableExport of var
   | MemoryExport of var
   | GlobalExport of var
+  | ExnExport of var
 
 type export = export' Source.phrase
 and export' =
@@ -179,6 +186,7 @@ and import_desc' =
   | TableImport of table_type
   | MemoryImport of memory_type
   | GlobalImport of global_type
+  | ExnImport of exn_type
 
 type import = import' Source.phrase
 and import' =
@@ -201,6 +209,7 @@ and module_' =
   data : string segment list;
   imports : import list;
   exports : export list;
+  exns : exn list
 }
 
 
@@ -218,6 +227,7 @@ let empty_module =
   data = [];
   imports = [];
   exports = [];
+  exns = []
 }
 
 open Source
@@ -232,6 +242,7 @@ let import_type (m : module_) (im : import) : extern_type =
   | TableImport t -> ExternTableType t
   | MemoryImport t -> ExternMemoryType t
   | GlobalImport t -> ExternGlobalType t
+  | ExnImport t -> ExternExnType t
 
 let export_type (m : module_) (ex : export) : extern_type =
   let {edesc; _} = ex.it in
@@ -251,6 +262,9 @@ let export_type (m : module_) (ex : export) : extern_type =
   | GlobalExport x ->
     let gts = globals its @ List.map (fun g -> g.it.gtype) m.it.globals in
     ExternGlobalType (nth gts x.it)
+  | ExnExport x ->
+    let ets = exns its @ List.map (fun e -> e.it.extype) m.it.exns in
+    ExternExnType (nth ets x.it)
 
 let string_of_name n =
   let b = Buffer.create 16 in

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -210,3 +210,4 @@ let memory_grow = MemoryGrow
 let try_ bt es1 es2 = Try (bt, es1, es2)
 let throw x = Throw x
 let rethrow = Rethrow
+let br_exn l x = BrExn (l, x)

--- a/interpreter/syntax/operators.ml
+++ b/interpreter/syntax/operators.ml
@@ -210,4 +210,4 @@ let memory_grow = MemoryGrow
 let try_ bt es1 es2 = Try (bt, es1, es2)
 let throw x = Throw x
 let rethrow = Rethrow
-let br_exn l x = BrExn (l, x)
+let br_on_exn l x = BrOnExn (l, x)

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -1,7 +1,7 @@
 (* Types *)
 
 type num_type = I32Type | I64Type | F32Type | F64Type
-type ref_type = NullRefType | AnyRefType | FuncRefType
+type ref_type = NullRefType | AnyRefType | FuncRefType | ExnRefType
 type value_type = NumType of num_type | RefType of ref_type
 type stack_type = value_type list
 type func_type = FuncType of stack_type * stack_type
@@ -11,11 +11,13 @@ type mutability = Immutable | Mutable
 type table_type = TableType of Int32.t limits * ref_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
+type exn_type = ExnType of stack_type
 type extern_type =
   | ExternFuncType of func_type
   | ExternTableType of table_type
   | ExternMemoryType of memory_type
   | ExternGlobalType of global_type
+  | ExternExnType of exn_type
 
 
 (* Attributes *)
@@ -60,7 +62,10 @@ let match_memory_type (MemoryType lim1) (MemoryType lim2) =
 
 let match_global_type (GlobalType (t1, mut1)) (GlobalType (t2, mut2)) =
   mut1 = mut2 &&
-  (t1 = t2 || mut2 = Immutable && match_value_type t1 t2)
+    (t1 = t2 || mut2 = Immutable && match_value_type t1 t2)
+
+let match_exn_type et1 et2 =
+  et1 = et2
 
 let match_extern_type et1 et2 =
   match et1, et2 with
@@ -68,6 +73,7 @@ let match_extern_type et1 et2 =
   | ExternTableType tt1, ExternTableType tt2 -> match_table_type tt1 tt2
   | ExternMemoryType mt1, ExternMemoryType mt2 -> match_memory_type mt1 mt2
   | ExternGlobalType gt1, ExternGlobalType gt2 -> match_global_type gt1 gt2
+  | ExternExnType et1, ExternExnType et2 -> match_exn_type et1 et2
   | _, _ -> false
 
 
@@ -125,6 +131,8 @@ let memories =
   Lib.List.map_filter (function ExternMemoryType t -> Some t | _ -> None)
 let globals =
   Lib.List.map_filter (function ExternGlobalType t -> Some t | _ -> None)
+let exns =
+  Lib.List.map_filter (function ExternExnType t -> Some t | _ -> None)
 
 
 (* String conversion *)
@@ -139,6 +147,7 @@ let string_of_ref_type = function
   | NullRefType -> "nullref"
   | AnyRefType -> "anyref"
   | FuncRefType -> "funcref"
+  | ExnRefType -> "exnref"
 
 let string_of_value_type = function
   | NumType t -> string_of_num_type t
@@ -169,8 +178,12 @@ let string_of_stack_type ts =
 let string_of_func_type (FuncType (ins, out)) =
   string_of_stack_type ins ^ " -> " ^ string_of_stack_type out
 
+let string_of_exn_type (ExnType ts) =
+  string_of_stack_type ts
+
 let string_of_extern_type = function
   | ExternFuncType ft -> "func " ^ string_of_func_type ft
   | ExternTableType tt -> "table " ^ string_of_table_type tt
   | ExternMemoryType mt -> "memory " ^ string_of_memory_type mt
   | ExternGlobalType gt -> "global " ^ string_of_global_type gt
+  | ExternExnType et -> "exception " ^ string_of_exn_type et

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -11,7 +11,7 @@ type mutability = Immutable | Mutable
 type table_type = TableType of Int32.t limits * ref_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
-type exn_type = ExnType of func_type
+type exn_type = func_type
 type extern_type =
   | ExternFuncType of func_type
   | ExternTableType of table_type
@@ -64,8 +64,7 @@ let match_global_type (GlobalType (t1, mut1)) (GlobalType (t2, mut2)) =
   mut1 = mut2 &&
     (t1 = t2 || mut2 = Immutable && match_value_type t1 t2)
 
-let match_exn_type et1 et2 =
-  et1 = et2
+let match_exn_type = match_func_type
 
 let match_extern_type et1 et2 =
   match et1, et2 with
@@ -178,8 +177,7 @@ let string_of_stack_type ts =
 let string_of_func_type (FuncType (ins, out)) =
   string_of_stack_type ins ^ " -> " ^ string_of_stack_type out
 
-let string_of_exn_type (ExnType ts) =
-  string_of_func_type ts
+let string_of_exn_type = string_of_func_type
 
 let string_of_extern_type = function
   | ExternFuncType ft -> "func " ^ string_of_func_type ft

--- a/interpreter/syntax/types.ml
+++ b/interpreter/syntax/types.ml
@@ -11,7 +11,7 @@ type mutability = Immutable | Mutable
 type table_type = TableType of Int32.t limits * ref_type
 type memory_type = MemoryType of Int32.t limits
 type global_type = GlobalType of value_type * mutability
-type exn_type = ExnType of stack_type
+type exn_type = ExnType of func_type
 type extern_type =
   | ExternFuncType of func_type
   | ExternTableType of table_type
@@ -179,7 +179,7 @@ let string_of_func_type (FuncType (ins, out)) =
   string_of_stack_type ins ^ " -> " ^ string_of_stack_type out
 
 let string_of_exn_type (ExnType ts) =
-  string_of_stack_type ts
+  string_of_func_type ts
 
 let string_of_extern_type = function
   | ExternFuncType ft -> "func " ^ string_of_func_type ft

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -73,7 +73,7 @@ let global_type = function
   | GlobalType (t, Immutable) -> atom string_of_value_type t
   | GlobalType (t, Mutable) -> Node ("mut", [atom string_of_value_type t])
 
-let exn_type (FuncType (ins, out)) =
+let exception_type (ExceptionType (ins, out)) =
   Node ("exception", decls "param" ins @ decls "result" out)
 
 
@@ -268,7 +268,7 @@ let rec instr e =
         [Node ("then", list instr es1); Node ("catch", list instr es2)]
     | Throw x -> "throw " ^ var x, []
     | Rethrow -> "rethrow", []
-    | BrExn (l, x) -> "br_on_exn" ^ (var l) ^ " " ^ (var x), []
+    | BrOnExn (l, x) -> "br_on_exn" ^ (var l) ^ " " ^ (var x), []
   in Node (head, inner)
 
 let const c =
@@ -329,7 +329,7 @@ let import_desc i d =
   | TableImport t -> table 0 i ({ttype = t} @@ d.at)
   | MemoryImport t -> memory 0 i ({mtype = t} @@ d.at)
   | GlobalImport t -> Node ("global $" ^ nat i, [global_type t])
-  | ExnImport t -> Node ("exception $" ^ nat i, [exn_type t])
+  | ExceptionImport t -> Node ("exception $" ^ nat i, [exception_type t])
 
 let import i im =
   let {module_name; item_name; idesc} = im.it in
@@ -343,7 +343,7 @@ let export_desc d =
   | TableExport x -> Node ("table", [atom var x])
   | MemoryExport x -> Node ("memory", [atom var x])
   | GlobalExport x -> Node ("global", [atom var x])
-  | ExnExport x -> Node ("exception", [atom var x])
+  | ExceptionExport x -> Node ("exception", [atom var x])
 
 let export ex =
   let {name = n; edesc} = ex.it in

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -73,6 +73,9 @@ let global_type = function
   | GlobalType (t, Immutable) -> atom string_of_value_type t
   | GlobalType (t, Mutable) -> Node ("mut", [atom string_of_value_type t])
 
+let exn_type (ExnType ts) =
+  Node ("exn", decls "param" ts)
+
 
 (* Operators *)
 
@@ -325,6 +328,7 @@ let import_desc i d =
   | TableImport t -> table 0 i ({ttype = t} @@ d.at)
   | MemoryImport t -> memory 0 i ({mtype = t} @@ d.at)
   | GlobalImport t -> Node ("global $" ^ nat i, [global_type t])
+  | ExnImport t -> Node ("exception $" ^ nat i, [exn_type t])
 
 let import i im =
   let {module_name; item_name; idesc} = im.it in
@@ -338,6 +342,7 @@ let export_desc d =
   | TableExport x -> Node ("table", [atom var x])
   | MemoryExport x -> Node ("memory", [atom var x])
   | GlobalExport x -> Node ("global", [atom var x])
+  | ExnExport x -> Node ("exception", [atom var x])
 
 let export ex =
   let {name = n; edesc} = ex.it in

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -73,8 +73,8 @@ let global_type = function
   | GlobalType (t, Immutable) -> atom string_of_value_type t
   | GlobalType (t, Mutable) -> Node ("mut", [atom string_of_value_type t])
 
-let exn_type (ExnType ft) =
-  Node ("exn", [func_type ft])
+let exn_type (FuncType (ins, out)) =
+  Node ("exception", decls "param" ins @ decls "result" out)
 
 
 (* Operators *)

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -268,7 +268,7 @@ let rec instr e =
         [Node ("then", list instr es1); Node ("catch", list instr es2)]
     | Throw x -> "throw " ^ var x, []
     | Rethrow -> "rethrow", []
-    | BrOnExn (l, x) -> "br_on_exn" ^ (var l) ^ " " ^ (var x), []
+    | BrOnExn (l, x) -> "br_on_exn " ^ (var l) ^ " " ^ (var x), []
   in Node (head, inner)
 
 let const c =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -268,6 +268,7 @@ let rec instr e =
         [Node ("then", list instr es1); Node ("catch", list instr es2)]
     | Throw x -> "throw " ^ var x, []
     | Rethrow -> "rethrow", []
+    | BrExn (l, x) -> "br_on_exn" ^ (var l) ^ " " ^ (var x), []
   in Node (head, inner)
 
 let const c =

--- a/interpreter/text/arrange.ml
+++ b/interpreter/text/arrange.ml
@@ -73,8 +73,8 @@ let global_type = function
   | GlobalType (t, Immutable) -> atom string_of_value_type t
   | GlobalType (t, Mutable) -> Node ("mut", [atom string_of_value_type t])
 
-let exn_type (ExnType ts) =
-  Node ("exn", decls "param" ts)
+let exn_type (ExnType ft) =
+  Node ("exn", [func_type ft])
 
 
 (* Operators *)

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -200,6 +200,10 @@ rule token = parse
   | "select" { SELECT }
   | "call" { CALL }
   | "call_indirect" { CALL_INDIRECT }
+  | "try" { TRY }
+  | "catch" { CATCH }
+  | "throw" { THROW }
+  | "rethrow" { RETHROW }
 
   | "local.get" { LOCAL_GET }
   | "local.set" { LOCAL_SET }
@@ -341,10 +345,6 @@ rule token = parse
   | "offset" { OFFSET }
   | "import" { IMPORT }
   | "export" { EXPORT }
-  | "try" { TRY }
-  | "catch" { CATCH }
-  | "throw" { THROW }
-  | "rethrow" { RETHROW }
   | "exception" { EXCEPTION }
 
   | "module" { MODULE }

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -162,6 +162,7 @@ rule token = parse
 
   | "anyref" { ANYREF }
   | "funcref" { FUNCREF }
+  | "exnref"  { EXNREF }
   | (nxx as t) { NUM_TYPE (num_type t) }
   | "mut" { MUT }
 
@@ -198,6 +199,12 @@ rule token = parse
   | "select" { SELECT }
   | "call" { CALL }
   | "call_indirect" { CALL_INDIRECT }
+
+  | "try" { TRY }
+  | "catch" { CATCH }
+  | "throw" { THROW }
+  | "rethrow" { RETHROW }
+  | "exception" { EXCEPTION }
 
   | "local.get" { LOCAL_GET }
   | "local.set" { LOCAL_SET }
@@ -373,12 +380,6 @@ rule token = parse
 
   | reserved { error lexbuf "unknown operator" }
   | utf8 { error lexbuf "malformed operator" }
-
-  | "try" { TRY }
-  | "catch" { CATCH }
-  | "throw" { THROW }
-  | "rethrow" { RETHROW }
-  | "exception" { EXCEPTION }
 
   | _ { error lexbuf "malformed UTF-8 encoding" }
 

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -118,7 +118,7 @@ let character =
     [^'"''\\''\x00'-'\x1f''\x7f'-'\xff']
   | utf8enc
   | '\\'escape
-  | '\\'hexdigit hexdigit 
+  | '\\'hexdigit hexdigit
   | "\\u{" hexnum '}'
 
 let nat = num | "0x" hexnum
@@ -192,7 +192,7 @@ rule token = parse
   | "br" { BR }
   | "br_if" { BR_IF }
   | "br_table" { BR_TABLE }
-    | "br_on_exn" { BR_EXN }
+  | "br_on_exn" { BR_ON_EXN }
   | "return" { RETURN }
   | "if" { IF }
   | "then" { THEN }
@@ -200,12 +200,6 @@ rule token = parse
   | "select" { SELECT }
   | "call" { CALL }
   | "call_indirect" { CALL_INDIRECT }
-
-  | "try" { TRY }
-  | "catch" { CATCH }
-  | "throw" { THROW }
-  | "rethrow" { RETHROW }
-  | "exception" { EXCEPTION }
 
   | "local.get" { LOCAL_GET }
   | "local.set" { LOCAL_SET }
@@ -347,6 +341,11 @@ rule token = parse
   | "offset" { OFFSET }
   | "import" { IMPORT }
   | "export" { EXPORT }
+  | "try" { TRY }
+  | "catch" { CATCH }
+  | "throw" { THROW }
+  | "rethrow" { RETHROW }
+  | "exception" { EXCEPTION }
 
   | "module" { MODULE }
   | "binary" { BIN }

--- a/interpreter/text/lexer.mll
+++ b/interpreter/text/lexer.mll
@@ -192,6 +192,7 @@ rule token = parse
   | "br" { BR }
   | "br_if" { BR_IF }
   | "br_table" { BR_TABLE }
+    | "br_on_exn" { BR_EXN }
   | "return" { RETURN }
   | "if" { IF }
   | "then" { THEN }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -235,7 +235,7 @@ def_type :
 
 exn_type :
   | func_type
-    { ExnType $1 }
+    { $1 }
 
 func_type :
   | /* empty */
@@ -652,15 +652,9 @@ func_body :
 
 /* Exceptions */
 exn :
-  | LPAR EXCEPTION bind_var_opt exn_sig RPAR
+  | LPAR EXCEPTION bind_var_opt exn_type RPAR
     { let at = at () in
-      fun c -> let x = $3 c anon_exn bind_exn @@ at in $4 c x }
-
-exn_sig :
-  | exn_type
-    { fun c x ->
-      let at = at () in
-      { extype = $1 } @@ at }
+      fun c -> let x = $3 c anon_exn bind_exn @@ at in { exvar = x; extype = $4 } @@ at }
 
 /* Tables, Memories & Globals */
 

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -234,10 +234,8 @@ def_type :
   | LPAR FUNC func_type RPAR { $3 }
 
 exn_type :
-  | /* empty */
-    { ExnType [] }
-  | LPAR PARAM value_type_list RPAR
-    { ExnType $3 }
+  | func_type
+    { ExnType $1 }
 
 func_type :
   | /* empty */
@@ -652,6 +650,17 @@ func_body :
     { fun c -> ignore (bind_local c $3); let f = $6 c in
       {f with locals = $4 :: f.locals} }
 
+/* Exceptions */
+exn :
+  | LPAR EXCEPTION bind_var_opt exn_sig RPAR
+    { let at = at () in
+      fun c -> let x = $3 c anon_exn bind_exn @@ at in $4 c x }
+
+exn_sig :
+  | exn_type
+    { fun c x ->
+      let at = at () in
+      { extype = $1 } @@ at }
 
 /* Tables, Memories & Globals */
 
@@ -865,6 +874,10 @@ module_fields1 :
     { fun c -> let mf = $2 c in
       fun () -> let m = mf () in
       {m with exports = $1 c :: m.exports} }
+  | exn module_fields
+    { fun c -> let mf = $2 c in
+      fun () -> let m = mf () in
+      {m with exns = $1 c :: m.exns} }
 
 module_var_opt :
   | /* empty */ { None }

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -85,10 +85,10 @@ let local (c : context) x = lookup "local" c.locals x
 let global (c : context) x = lookup "global" c.globals x
 let table (c : context) x = lookup "table" c.tables x
 let memory (c : context) x = lookup "memory" c.memories x
+let exception_ (c : context) x = lookup "exception" c.exceptions x
 let label (c : context) x =
   try VarMap.find x.it c.labels
   with Not_found -> error x.at ("unknown label " ^ x.it)
-let exception_ (c : context) x = lookup "exception" c.exceptions x
 
 let func_type (c : context) x =
   try (Lib.List32.nth c.types.list x.it).it
@@ -113,9 +113,9 @@ let bind_local (c : context) x = bind "local" c.locals x
 let bind_global (c : context) x = bind "global" c.globals x
 let bind_table (c : context) x = bind "table" c.tables x
 let bind_memory (c : context) x = bind "memory" c.memories x
+let bind_exception (c : context) x = bind "exception" c.exceptions x
 let bind_label (c : context) x =
   {c with labels = VarMap.add x.it 0l (VarMap.map (Int32.add 1l) c.labels)}
-let bind_exception (c : context) x = bind "exception" c.exceptions x
 
 let anon category space n =
   let i = space.count in
@@ -133,9 +133,9 @@ let anon_locals (c : context) ts =
 let anon_global (c : context) = anon "global" c.globals 1l
 let anon_table (c : context) = anon "table" c.tables 1l
 let anon_memory (c : context) = anon "memory" c.memories 1l
+let anon_exception (c : context) = anon "exception" c.exceptions 1l
 let anon_label (c : context) =
   {c with labels = VarMap.map (Int32.add 1l) c.labels}
-let anon_exception (c : context) = anon "exception" c.exceptions 1l
 
 let inline_type (c : context) ft at =
   match Lib.List.index_where (fun ty -> ty.it = ft) c.types.list with
@@ -875,7 +875,7 @@ module_fields1 :
   | elem module_fields
     { fun c -> let mf = $2 c in
       fun () -> let m = mf () in
-    {m with elems = $1 c :: m.elems} }
+      {m with elems = $1 c :: m.elems} }
   | data module_fields
     { fun c -> let mf = $2 c in
       fun () -> let m = mf () in

--- a/interpreter/text/parser.mly
+++ b/interpreter/text/parser.mly
@@ -156,7 +156,7 @@ let block_type at (c : context) = function
 %token LPAR RPAR
 %token NAT INT FLOAT STRING VAR
 %token ANYREF FUNCREF EXNREF NUM_TYPE MUT
-%token NOP DROP BLOCK END IF THEN ELSE SELECT LOOP BR BR_IF BR_TABLE
+%token NOP DROP BLOCK END IF THEN ELSE SELECT LOOP BR BR_IF BR_TABLE BR_EXN
 %token CALL CALL_INDIRECT RETURN
 %token LOCAL_GET LOCAL_SET LOCAL_TEE GLOBAL_GET GLOBAL_SET TABLE_GET TABLE_SET
 %token LOAD STORE OFFSET_EQ_NAT ALIGN_EQ_NAT
@@ -331,6 +331,7 @@ plain_instr :
   | BR_TABLE var var_list
     { fun c -> let xs, x = Lib.List.split_last ($2 c label :: $3 c label) in
       br_table xs x }
+  | BR_EXN var var { fun c -> br_exn ($2 c label) ($3 c exn) }
   | RETURN { fun c -> return }
   | CALL var { fun c -> call ($2 c func) }
   | LOCAL_GET var { fun c -> local_get ($2 c local) }

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -420,8 +420,8 @@ let check_global_type (gt : global_type) at =
   check_value_type t at
 
 let check_exn_type (et : exn_type) at =
-  let ExnType ts = et in
-  List.iter (fun t -> check_value_type t at) ts
+  let ExnType ft = et in
+  check_func_type ft at
 
 let check_type (t : type_) =
   check_func_type t.it t.at

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -419,8 +419,7 @@ let check_global_type (gt : global_type) at =
   let GlobalType (t, mut) = gt in
   check_value_type t at
 
-let check_exn_type (et : exn_type) at =
-  let ExnType ft = et in
+let check_exn_type (ft : exn_type) at =
   check_func_type ft at
 
 let check_type (t : type_) =

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -356,6 +356,7 @@ let rec check_instr (c : context) (e : instr) (s : infer_stack_type) : op_type =
   | Try _ -> assert false (* TODO FIXME. *)
   | Throw _ -> assert false (* TODO FIXME. *)
   | Rethrow -> assert false (* TODO FIXME. *)
+  | BrExn _ -> assert false (* TODO FIXME. *)
 
 and check_seq (c : context) (s : infer_stack_type) (es : instr list)
   : infer_stack_type =

--- a/interpreter/valid/valid.ml
+++ b/interpreter/valid/valid.ml
@@ -545,6 +545,7 @@ let check_module (m : module_) =
       funcs = c0.funcs @ List.map (fun f -> type_ c0 f.it.ftype) funcs;
       tables = c0.tables @ List.map (fun tab -> tab.it.ttype) tables;
       memories = c0.memories @ List.map (fun mem -> mem.it.mtype) memories;
+      exceptions = c0.exceptions @ List.map (fun exn -> exn.it.xtype) exceptions;
     }
   in
   let c =

--- a/test/core/exception.wast
+++ b/test/core/exception.wast
@@ -1,0 +1,5 @@
+;; Test `exception` declarations.
+
+(module
+  (exception $1 (result))
+)

--- a/test/core/exception.wast
+++ b/test/core/exception.wast
@@ -1,7 +1,8 @@
 ;; Test `exception` declarations.
 
 (module
-  (exception $1 (result))
-  (exception $2 (param i32) (param i64) (result))
-  (export "fail" (exception $1))
+  (exception (result))
+  (exception $1 (param i32) (param i64) (result))
+  (exception (export "Not_found") (result))
+  (export "fail" (exception 0))
 )

--- a/test/core/exception.wast
+++ b/test/core/exception.wast
@@ -2,4 +2,6 @@
 
 (module
   (exception $1 (result))
+  (exception $2 (param i32) (param i64) (result))
+  (export "fail" (exception $1))
 )


### PR DESCRIPTION
This PR adds syntax for declaration, import, and export of exceptions as well as the `br_on_exn` branch instruction. It also adds a test module for exceptions (incomplete at the moment).

There seems to be a problem with the scoping of exceptions at the moment. I suppose the exceptions aren't be added to the context properly. Furthermore, I have not added any syntactic sugar for importing and exporting exceptions; I figured you may have an opinion on whether to add any sugar, and if so what it should be.